### PR TITLE
net: Add header data to net_* tracepoints

### DIFF
--- a/instrumentation/events/lttng-module/net.h
+++ b/instrumentation/events/lttng-module/net.h
@@ -8,7 +8,188 @@
 #include <linux/skbuff.h>
 #include <linux/netdevice.h>
 #include <linux/ip.h>
+#include <linux/ipv6.h>
+#include <linux/tcp.h>
 #include <linux/version.h>
+#include <lttng-endian.h>
+#include <net/sock.h>
+
+#ifndef ONCE_LTTNG_NET_H
+#define ONCE_LTTNG_NET_H
+
+static inline unsigned char __has_network_hdr(struct sk_buff *skb)
+{
+	/* If the header is not set yet,
+	 * the network header will point to the head. */
+	return skb_network_header(skb) != skb->head;
+}
+
+static struct lttng_event_field emptyfields[] = {
+};
+
+/* Structures for network headers. */
+
+static struct lttng_event_field ipv4fields[] = {
+	[0] = {
+		.name = "version",
+		.type = __type_integer(uint8_t, 4, 4, 0, __BIG_ENDIAN, 10, none),
+	},
+	[1] = {
+		.name = "ihl",
+		.type = __type_integer(uint8_t, 4, 4, 0, __BIG_ENDIAN, 10, none),
+	},
+	[2] = {
+		.name = "tos",
+		.type = __type_integer(uint8_t, 0, 0, 0, __BIG_ENDIAN, 10, none),
+	},
+	[3] = {
+		.name = "tot_len",
+		.type = __type_integer(uint16_t, 0, 0, 0, __BIG_ENDIAN, 10, none),
+	},
+	[4] = {
+		.name = "id",
+		.type = __type_integer(uint16_t, 0, 0, 0, __BIG_ENDIAN, 16, none),
+	},
+	[5] = {
+		.name = "frag_off",
+		.type = __type_integer(uint16_t, 0, 0, 0, __BIG_ENDIAN, 10, none),
+	},
+	[6] = {
+		.name = "ttl",
+		.type = __type_integer(uint8_t, 0, 0, 0, __BIG_ENDIAN, 10, none),
+	},
+	[7] = {
+		.name = "protocol",
+		.type = __type_integer(uint8_t, 0, 0, 0, __BIG_ENDIAN, 16, none),
+	},
+	[8] = {
+		.name = "checksum",
+		.type = __type_integer(uint16_t, 0, 0, 0, __BIG_ENDIAN, 16, none),
+	},
+	[9] = {
+		.name = "saddr",
+		.type = {
+			.atype = atype_array,
+			.u.array.elem_type = __type_integer(uint8_t, 0, 0, 0, __BIG_ENDIAN, 10, none),
+			.u.array.length = 4,
+			.u.array.elem_alignment = lttng_alignof(uint8_t),
+		},
+	},
+	[10] = {
+		.name = "daddr",
+		.type = {
+			.atype = atype_array,
+			.u.array.elem_type = __type_integer(uint8_t, 0, 0, 0, __BIG_ENDIAN, 10, none),
+			.u.array.length = 4,
+			.u.array.elem_alignment = lttng_alignof(uint8_t),
+		},
+	},
+};
+
+static struct lttng_event_field ipv6fields[] = {
+	[0] = {
+		.name = "version",
+		.type = __type_integer(uint8_t, 4, 4, 0, __BIG_ENDIAN, 10, none),
+	},
+	[1] = {
+		.name = "prio",
+		.type = __type_integer(uint8_t, 4, 4, 0, __BIG_ENDIAN, 10, none),
+	},
+	[2] = {
+		.name = "flow_lbl",
+		.type = {
+			.atype = atype_array,
+			.u.array.elem_type = __type_integer(uint8_t, 0, 0, 0, __BIG_ENDIAN, 10, none),
+			.u.array.length = 3,
+			.u.array.elem_alignment = lttng_alignof(uint8_t),
+		},
+	},
+	[3] = {
+		.name = "payload_len",
+		.type = __type_integer(uint16_t, 0, 0, 0, __BIG_ENDIAN, 10, none),
+	},
+	[4] = {
+		.name = "nexthdr",
+		.type = __type_integer(uint8_t, 0, 0, 0, __BIG_ENDIAN, 16, none),
+	},
+	[5] = {
+		.name = "hop_limit",
+		.type = __type_integer(uint8_t, 0, 0, 0, __BIG_ENDIAN, 10, none),
+	},
+	[6] = {
+		.name = "saddr",
+		.type = {
+			.atype = atype_array,
+			.u.array.elem_type = __type_integer(uint16_t, 0, 0, 0, __BIG_ENDIAN, 16, none),
+			.u.array.length = 8,
+			.u.array.elem_alignment = lttng_alignof(uint16_t),
+		},
+	},
+	[7] = {
+		.name = "daddr",
+		.type = {
+			.atype = atype_array,
+			.u.array.elem_type = __type_integer(uint16_t, 0, 0, 0, __BIG_ENDIAN, 16, none),
+			.u.array.length = 8,
+			.u.array.elem_alignment = lttng_alignof(uint16_t),
+		},
+	},
+};
+
+static struct lttng_event_field network_fields[] = {
+	[0] = {
+		.name = "unknown",
+		.type = {
+			.atype = atype_struct,
+			.u._struct.nr_fields = 0,
+			.u._struct.fields = emptyfields,
+		},
+	},
+	[1] = {
+		.name = "ipv4",
+		.type = {
+			.atype = atype_struct,
+			.u._struct.nr_fields = ARRAY_SIZE(ipv4fields),
+			.u._struct.fields = ipv4fields,
+		},
+	},
+	[2] = {
+		.name = "ipv6",
+		.type = {
+			.atype = atype_struct,
+			.u._struct.nr_fields = ARRAY_SIZE(ipv6fields),
+			.u._struct.fields = ipv6fields,
+		},
+	},
+};
+
+enum network_header_types {
+	NH_NONE,
+	NH_IPV4,
+	NH_IPV6,
+};
+
+static inline unsigned char __get_network_header_type(struct sk_buff *skb)
+{
+	if (__has_network_hdr(skb)) {
+		if (skb->protocol == htons(ETH_P_IPV6))
+			return NH_IPV6;
+		else if (skb->protocol == htons(ETH_P_IP))
+			return NH_IPV4;
+		/* Fallthrough for other header types. */
+	}
+	return NH_NONE;
+}
+
+#endif
+
+LTTNG_TRACEPOINT_ENUM(net_network_header,
+	TP_ENUM_VALUES(
+		ctf_enum_value("_unknown", NH_NONE)
+		ctf_enum_value("_ipv4", NH_IPV4)
+		ctf_enum_value("_ipv6", NH_IPV6)
+	)
+)
 
 LTTNG_TRACEPOINT_EVENT(net_dev_xmit,
 
@@ -49,6 +230,36 @@ LTTNG_TRACEPOINT_EVENT_CLASS(net_dev_template,
 		ctf_integer_hex(void *, skbaddr, skb)
 		ctf_integer(unsigned int, len, skb->len)
 		ctf_string(name, skb->dev->name)
+		ctf_enum(net_network_header, unsigned char,
+			network_header_type, __get_network_header_type(skb))
+		ctf_custom_field(
+			ctf_custom_type(
+				.atype = atype_variant,
+				.u.variant.tag_name = "network_header_type",
+				.u.variant.choices = network_fields,
+				.u.variant.nr_choices = ARRAY_SIZE(network_fields),
+			),
+			network_header,
+			ctf_custom_code(
+				switch (__get_network_header_type(skb)) {
+				case NH_IPV4: {
+					ctf_align(uint16_t)
+					ctf_array_type(uint8_t, ip_hdr(skb),
+							sizeof(struct iphdr))
+					break;
+				}
+				case NH_IPV6: {
+					ctf_align(uint16_t)
+					ctf_array_type(uint8_t, ipv6_hdr(skb),
+							sizeof(struct ipv6hdr))
+					break;
+				}
+				default:
+					/* For any other header type, there is nothing to do. */
+					break;
+				}
+			)
+		)
 	)
 )
 

--- a/instrumentation/events/lttng-module/net.h
+++ b/instrumentation/events/lttng-module/net.h
@@ -27,6 +27,110 @@ static inline unsigned char __has_network_hdr(struct sk_buff *skb)
 static struct lttng_event_field emptyfields[] = {
 };
 
+/* Structures for transport headers. */
+
+static struct lttng_event_field tcpfields[] = {
+	[0] = {
+		.name = "source",
+		.type = __type_integer(uint16_t, 0, 0, 0, __BIG_ENDIAN, 10, none),
+	},
+	[1] = {
+		.name = "dest",
+		.type = __type_integer(uint16_t, 0, 0, 0, __BIG_ENDIAN, 10, none),
+	},
+	[2] = {
+		.name = "seq",
+		.type = __type_integer(uint32_t, 0, 0, 0, __BIG_ENDIAN, 16, none),
+	},
+	[3] = {
+		.name = "ack_seq",
+		.type = __type_integer(uint32_t, 0, 0, 0, __BIG_ENDIAN, 16, none),
+	},
+	[4] = {
+		.name = "flags",
+		.type = __type_integer(uint16_t, 0, 0, 0, __BIG_ENDIAN, 16, none),
+	},
+	[5] = {
+		.name = "window",
+		.type = __type_integer(uint16_t, 0, 0, 0, __BIG_ENDIAN, 10, none),
+	},
+	[6] = {
+		.name = "check",
+		.type = __type_integer(uint16_t, 0, 0, 0, __BIG_ENDIAN, 16, none),
+	},
+	[7] = {
+		.name = "urg_ptr",
+		.type = __type_integer(uint16_t, 0, 0, 0, __BIG_ENDIAN, 16, none),
+	},
+};
+
+static struct lttng_event_field transport_fields[] = {
+	[0] = {
+		.name = "unknown",
+		.type = {
+			.atype = atype_struct,
+			.u._struct.nr_fields = ARRAY_SIZE(emptyfields),
+			.u._struct.fields = emptyfields,
+		},
+	},
+	[1] = {
+		.name = "tcp",
+		.type = {
+			.atype = atype_struct,
+			.u._struct.nr_fields = ARRAY_SIZE(tcpfields),
+			.u._struct.fields = tcpfields,
+		},
+	},
+};
+
+enum transport_header_types {
+	TH_NONE,
+	TH_TCP,
+};
+
+static inline unsigned char __get_transport_header_type(struct sk_buff *skb)
+{
+	if (__has_network_hdr(skb)) {
+		/* When both transport and network header are set, transport header
+		 * is greater than network header, otherwise it points to head. */
+		if (skb->transport_header > skb->network_header) {
+			/* Get the transport protocol from the network header's data.
+			 * This method works both for sent and received packets. */
+			if ((skb->protocol == htons(ETH_P_IP) &&
+					ip_hdr(skb)->protocol == IPPROTO_TCP) ||
+				(skb->protocol == htons(ETH_P_IPV6) &&
+					ipv6_hdr(skb)->nexthdr == IPPROTO_TCP))
+				return TH_TCP;
+		}
+		/* Fallthrough for other cases where header is not TCP. */
+	}
+	return TH_NONE;
+}
+
+static struct lttng_enum_entry transport_enum_entries[] = {
+	[0] = {
+		.start = { .value = 0, .signedness = 0, },
+		.end = { .value = IPPROTO_TCP - 1, .signedness = 0, },
+		.string = "_unknown",
+	},
+	[1] = {
+		.start = { .value = IPPROTO_TCP, .signedness = 0, },
+		.end = { .value = IPPROTO_TCP, .signedness = 0, },
+		.string = "_tcp",
+	},
+	[2] = {
+		.start = { .value = IPPROTO_TCP + 1, .signedness = 0, },
+		.end = { .value = 255, .signedness = 0, },
+		.string = "_unknown",
+	},
+};
+
+static const struct lttng_enum_desc transport_header_type = {
+	.name = "transport_header_type",
+	.entries = transport_enum_entries,
+	.nr_entries = ARRAY_SIZE(transport_enum_entries),
+};
+
 /* Structures for network headers. */
 
 static struct lttng_event_field ipv4fields[] = {
@@ -60,7 +164,18 @@ static struct lttng_event_field ipv4fields[] = {
 	},
 	[7] = {
 		.name = "protocol",
-		.type = __type_integer(uint8_t, 0, 0, 0, __BIG_ENDIAN, 16, none),
+		.type = {
+			.atype = atype_enum,
+			.u.basic.enumeration.desc = &transport_header_type,
+			.u.basic.enumeration.container_type = {
+				.size = 8,
+				.alignment = 8,
+				.signedness = 0,
+				.reverse_byte_order = __BIG_ENDIAN != __BYTE_ORDER,
+				.base = 16,
+				.encoding = lttng_encode_none,
+			},
+		},
 	},
 	[8] = {
 		.name = "checksum",
@@ -82,6 +197,15 @@ static struct lttng_event_field ipv4fields[] = {
 			.u.array.elem_type = __type_integer(uint8_t, 0, 0, 0, __BIG_ENDIAN, 10, none),
 			.u.array.length = 4,
 			.u.array.elem_alignment = lttng_alignof(uint8_t),
+		},
+	},
+	[11] = {
+		.name = "transport_header",
+		.type = {
+			.atype = atype_variant,
+			.u.variant.tag_name = "protocol",
+			.u.variant.choices = transport_fields,
+			.u.variant.nr_choices = ARRAY_SIZE(transport_fields),
 		},
 	},
 };
@@ -110,7 +234,18 @@ static struct lttng_event_field ipv6fields[] = {
 	},
 	[4] = {
 		.name = "nexthdr",
-		.type = __type_integer(uint8_t, 0, 0, 0, __BIG_ENDIAN, 16, none),
+		.type = {
+			.atype = atype_enum,
+			.u.basic.enumeration.desc = &transport_header_type,
+			.u.basic.enumeration.container_type = {
+				.size = 8,
+				.alignment = 8,
+				.signedness = 0,
+				.reverse_byte_order = __BIG_ENDIAN != __BYTE_ORDER,
+				.base = 16,
+				.encoding = lttng_encode_none,
+			},
+		},
 	},
 	[5] = {
 		.name = "hop_limit",
@@ -132,6 +267,15 @@ static struct lttng_event_field ipv6fields[] = {
 			.u.array.elem_type = __type_integer(uint16_t, 0, 0, 0, __BIG_ENDIAN, 16, none),
 			.u.array.length = 8,
 			.u.array.elem_alignment = lttng_alignof(uint16_t),
+		},
+	},
+	[8] = {
+		.name = "transport_header",
+		.type = {
+			.atype = atype_variant,
+			.u.variant.tag_name = "nexthdr",
+			.u.variant.choices = transport_fields,
+			.u.variant.nr_choices = ARRAY_SIZE(transport_fields),
 		},
 	},
 };
@@ -181,6 +325,8 @@ static inline unsigned char __get_network_header_type(struct sk_buff *skb)
 	return NH_NONE;
 }
 
+
+
 #endif
 
 LTTNG_TRACEPOINT_ENUM(net_network_header,
@@ -188,6 +334,13 @@ LTTNG_TRACEPOINT_ENUM(net_network_header,
 		ctf_enum_value("_unknown", NH_NONE)
 		ctf_enum_value("_ipv4", NH_IPV4)
 		ctf_enum_value("_ipv6", NH_IPV6)
+	)
+)
+
+LTTNG_TRACEPOINT_ENUM(net_transport_header,
+	TP_ENUM_VALUES(
+		ctf_enum_value("_none", TH_NONE)
+		ctf_enum_value("_tcp", TH_TCP)
 	)
 )
 
@@ -241,6 +394,7 @@ LTTNG_TRACEPOINT_EVENT_CLASS(net_dev_template,
 			),
 			network_header,
 			ctf_custom_code(
+				/* Copy the network header */
 				switch (__get_network_header_type(skb)) {
 				case NH_IPV4: {
 					ctf_align(uint16_t)
@@ -258,6 +412,14 @@ LTTNG_TRACEPOINT_EVENT_CLASS(net_dev_template,
 					/* For any other header type, there is nothing to do. */
 					break;
 				}
+
+				/* Copy the transport header */
+				if (__get_transport_header_type(skb) == TH_TCP) {
+					ctf_align(uint32_t)
+					ctf_array_type(uint8_t, tcp_hdr(skb),
+							sizeof(struct tcphdr))
+				}
+				/* For any other header type, there is nothing to do. */
 			)
 		)
 	)

--- a/lttng-events.c
+++ b/lttng-events.c
@@ -1909,7 +1909,7 @@ int _lttng_enum_statedump(struct lttng_session *session,
 	if (ret)
 		goto end;
 	ret = lttng_metadata_printf(session,
-		"enum : integer { size = %u; align = %u; signed = %u; encoding = %s; base = %u; } {\n",
+		"enum : integer { size = %u; align = %u; signed = %u; encoding = %s; base = %u;%s } {\n",
 		container_type->size,
 		container_type->alignment,
 		container_type->signedness,
@@ -1918,7 +1918,13 @@ int _lttng_enum_statedump(struct lttng_session *session,
 			: (container_type->encoding == lttng_encode_UTF8)
 				? "UTF8"
 				: "ASCII",
-		container_type->base);
+		container_type->base,
+#if __BYTE_ORDER == __BIG_ENDIAN
+		container_type->reverse_byte_order ? " byte_order = le;" : ""
+#else
+		container_type->reverse_byte_order ? " byte_order = be;" : ""
+#endif
+		);
 	if (ret)
 	        goto end;
 	/* Dump all entries */


### PR DESCRIPTION
This branch adds TCP and IPv4/IPv6 header data to net_* tracepoint using variant fields. This data will be useful among other things to synchronize traces from different machines.