### PR TITLE
**RFC** Add data to link guest traces and host processes

### DIFF
--- a/instrumentation/events/lttng-module/lttng-statedump.h
+++ b/instrumentation/events/lttng-module/lttng-statedump.h
@@ -138,6 +138,16 @@ LTTNG_TRACEPOINT_EVENT(lttng_statedump_interrupt,
 	)
 )
 
+LTTNG_TRACEPOINT_EVENT(lttng_statedump_kvm_guest,
+	TP_PROTO(struct lttng_session *session,
+		int pid, const char *guest_uuid),
+	TP_ARGS(session, pid, guest_uuid),
+	TP_FIELDS(
+		ctf_integer(int, pid, pid)
+		ctf_string(uuid, guest_uuid)
+	)
+)
+
 #endif /*  LTTNG_TRACE_LTTNG_STATEDUMP_H */
 
 /* This part must be outside protection */

--- a/lttng-events.c
+++ b/lttng-events.c
@@ -40,6 +40,7 @@
 #include <linux/jhash.h>
 #include <linux/uaccess.h>
 #include <linux/vmalloc.h>
+#include <linux/dmi.h>
 
 #include <wrapper/uuid.h>
 #include <wrapper/vmalloc.h>	/* for wrapper_vmalloc_sync_all() */
@@ -2450,6 +2451,7 @@ int _lttng_session_metadata_statedump(struct lttng_session *session)
 {
 	unsigned char *uuid_c = session->uuid.b;
 	unsigned char uuid_s[37], clock_uuid_s[BOOT_ID_LEN];
+	const char *product_uuid;
 	struct lttng_channel *chan;
 	struct lttng_event *event;
 	int ret = 0;
@@ -2465,6 +2467,8 @@ int _lttng_session_metadata_statedump(struct lttng_session *session)
 		uuid_c[4], uuid_c[5], uuid_c[6], uuid_c[7],
 		uuid_c[8], uuid_c[9], uuid_c[10], uuid_c[11],
 		uuid_c[12], uuid_c[13], uuid_c[14], uuid_c[15]);
+
+	product_uuid = dmi_get_system_info(DMI_PRODUCT_UUID);
 
 	ret = lttng_metadata_printf(session,
 		"typealias integer { size = 8; align = %u; signed = false; } := uint8_t;\n"
@@ -2516,6 +2520,7 @@ int _lttng_session_metadata_statedump(struct lttng_session *session)
 		"	tracer_major = %d;\n"
 		"	tracer_minor = %d;\n"
 		"	tracer_patchlevel = %d;\n"
+		"	product_uuid = \"%s\";\n"
 		"};\n\n",
 		current->nsproxy->uts_ns->name.nodename,
 		utsname()->sysname,
@@ -2523,7 +2528,8 @@ int _lttng_session_metadata_statedump(struct lttng_session *session)
 		utsname()->version,
 		LTTNG_MODULES_MAJOR_VERSION,
 		LTTNG_MODULES_MINOR_VERSION,
-		LTTNG_MODULES_PATCHLEVEL_VERSION
+		LTTNG_MODULES_PATCHLEVEL_VERSION,
+		product_uuid
 		);
 	if (ret)
 		goto end;

--- a/lttng-statedump-impl.c
+++ b/lttng-statedump-impl.c
@@ -46,6 +46,11 @@
 #include <linux/wait.h>
 #include <linux/mutex.h>
 #include <linux/device.h>
+#include <linux/kvm_host.h>
+#include <linux/dcache.h>
+#include <linux/fs.h>
+#include <linux/mm.h>
+#include <linux/uaccess.h>
 
 #include <lttng-events.h>
 #include <lttng-tracer.h>
@@ -77,6 +82,7 @@ DEFINE_TRACE(lttng_statedump_file_descriptor);
 DEFINE_TRACE(lttng_statedump_start);
 DEFINE_TRACE(lttng_statedump_process_state);
 DEFINE_TRACE(lttng_statedump_network_interface);
+DEFINE_TRACE(lttng_statedump_kvm_guest);
 
 struct lttng_fd_ctx {
 	char *page;
@@ -121,6 +127,9 @@ enum lttng_process_status {
 	LTTNG_RUN = 6,
 	LTTNG_DEAD = 7,
 };
+
+#define QEMU_KVM_UUID_LEN	37
+#define QEMU_KVM_UUID_ARG_LEN QEMU_KVM_UUID_LEN + 6
 
 static
 int lttng_enumerate_block_devices(struct lttng_session *session)
@@ -491,6 +500,118 @@ int lttng_enumerate_process_states(struct lttng_session *session)
 }
 
 static
+int lttng_get_kvm_pid(const char* name, char *pid) {
+	int i = 0;
+	const char *s = name;
+
+	/* If the file name has format (\d{1,5})-(.*), copy the first numeric
+	 * part in the pid string, that would be the guest pid
+	 *
+	 * FIXME: Have the pid string internal only and have the actual pid
+	 * numeric value in the parameters */
+	while ((*s != '\0') && (i < 5) && (*s != '-')
+			&& (*s >= '0' && *s <= '9')) {
+		pid[i] = *s;
+		i++;
+		s++;
+	}
+	pid[i] = '\0';
+	if (*s == '-')
+		return 0;
+
+	return 1;
+}
+
+/**
+ * Get the -uuid argument from a command line file. The filename should be
+ * in the form of /proc/<pid>/cmdline
+ *
+ * FIXME: Receive the numeric pid in parameter instead of the filename
+ */
+static
+int lttng_get_uuid_from_proc_cmdline(const char* filename, char *uuid) {
+	struct file *file;
+	int ret, i = 0, j;
+	ssize_t len;
+	mm_segment_t old_fs;
+	char content[1920];
+	uuid[0] = '\0';
+
+	// Open the cmdline file
+	file = filp_open(filename, O_RDONLY, 0);
+	if (IS_ERR(file))
+		return PTR_ERR(file);
+
+	old_fs = get_fs();
+	set_fs(KERNEL_DS);
+
+	if (!file->f_op || !file->f_op->read) {
+		ret = -EINVAL;
+		goto end;
+	}
+
+	// Read the content of the file
+	len = file->f_op->read(file, content, 1920 - 1, &file->f_pos);
+	if (len < 0) {
+		ret = -EINVAL;
+		goto end;
+	}
+	ret = -ENODEV;
+	while (i < len - QEMU_KVM_UUID_ARG_LEN - 1) {
+		/* Look for the -uuid string and copy the uuid characters
+		 * to the uuid string */
+		if (content[i] == '-' && content[i+1] == 'u' && content[i+2] == 'u'
+				&& content[i+3] == 'i' && content[i+4] == 'd') {
+			i+=6;
+			j = 0;
+			for (j = 0; j < QEMU_KVM_UUID_LEN - 1; j++, i++) {
+				uuid[j] = content[i];
+			}
+			uuid[QEMU_KVM_UUID_LEN - 1] = '\0';
+			ret = 0;
+		}
+		i++;
+	}
+
+end:
+	set_fs(old_fs);
+	filp_close(file, current->files);
+	return ret;
+}
+
+static
+int lttng_enumerate_kvm_guests(struct lttng_session *session)
+{
+	struct dentry *kvm_debugfs;
+	struct list_head *q, *n;
+	struct dentry *kvm_child;
+	char pidstr[6];
+	char uuid[QEMU_KVM_UUID_LEN];
+	unsigned int pid;
+	char cmdline_file[64];
+
+	rcu_read_lock();
+
+	kvm_debugfs = kvm_debugfs_dir;
+
+	if (kvm_debugfs != NULL) {
+		list_for_each_safe(q, n, &kvm_debugfs->d_subdirs) {
+			kvm_child = list_entry(q, struct dentry, d_child);
+			if (!lttng_get_kvm_pid(kvm_child->d_name.name, pidstr)) {
+				if (!kstrtouint(pidstr, 10, &pid)) {
+					sprintf(cmdline_file, "/proc/%s/cmdline", pidstr);
+					lttng_get_uuid_from_proc_cmdline(cmdline_file, uuid);
+					trace_lttng_statedump_kvm_guest(session, pid, uuid);
+				}
+			}
+		}
+	}
+	rcu_read_unlock();
+
+	return 0;
+}
+
+static
 void lttng_statedump_work_func(struct work_struct *work)
 {
 	if (atomic_dec_and_test(&kernel_threads_to_run))
@@ -532,6 +653,9 @@ int do_lttng_statedump(struct lttng_session *session)
 	default:
 		return ret;
 	}
+	ret = lttng_enumerate_kvm_guests(session);
+	if (ret)
+		return ret;
 
 	/* TODO lttng_dump_idt_table(session); */
 	/* TODO lttng_dump_softirq_vec(session); */


### PR DESCRIPTION
This patch is the ideal path to statedump kvm guest data.

I'd like to know if there's anything in the approach (ie parsing debugfs entry names and process command lines) that would jeopardize this branch's chances of making it upstream.

If that's fine, I'll clean it up (add proper kernel version ifs and elses, fix the fixmes, make the code cleaner, etc)