### PR TITLE
Fix userspace probe build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,7 @@ ifneq ($(KERNELRELEASE),)
                        lttng-filter-specialize.o \
                        lttng-filter-validator.o \
                        probes/lttng-probe-user.o \
-                       lttng-tp-mempool.o \
-                       probes/lttng-uprobes.o
+                       lttng-tp-mempool.o
 
   ifneq ($(CONFIG_HAVE_SYSCALL_TRACEPOINTS),)
     lttng-tracer-objs += lttng-syscalls.o

--- a/lttng-events.h
+++ b/lttng-events.h
@@ -785,6 +785,7 @@ void lttng_kprobes_destroy_private(struct lttng_event *event)
 
 int lttng_event_add_callsite(struct lttng_event *event,
 	struct lttng_kernel_event_callsite *callsite);
+
 #ifdef CONFIG_UPROBES
 int lttng_uprobes_register(const char *name,
 	int fd, struct lttng_event *event);
@@ -802,7 +803,7 @@ int lttng_uprobes_register(const char *name,
 
 static inline
 int lttng_uprobes_add_callsite(struct lttng_event *event,
-	struct lttng_kernel_callsite_uprobe *callsite)
+	struct lttng_kernel_event_callsite *callsite)
 {
 	return -ENOSYS;
 }

--- a/probes/Kbuild
+++ b/probes/Kbuild
@@ -263,6 +263,10 @@ ifneq ($(CONFIG_KPROBES),)
   obj-$(CONFIG_LTTNG) += lttng-kprobes.o
 endif # CONFIG_KPROBES
 
+ifneq ($(CONFIG_UPROBES),)
+  obj-$(CONFIG_LTTNG) += lttng-uprobes.o
+endif # CONFIG_UPROBES
+
 ifneq ($(CONFIG_KRETPROBES),)
   obj-$(CONFIG_LTTNG) += lttng-kretprobes.o
 endif # CONFIG_KRETPROBES

--- a/probes/lttng-uprobes.c
+++ b/probes/lttng-uprobes.c
@@ -67,7 +67,7 @@ int lttng_uprobes_handler_pre(struct uprobe_consumer *uc, struct pt_regs *regs)
 		return 0;
 
 	/* Event payload. */
-	payload.ip = regs->ip;
+	payload.ip = (unsigned long)instruction_pointer(regs);
 
 	lib_ring_buffer_align_ctx(&ctx, lttng_alignof(payload));
 	chan->ops->event_write(&ctx, &payload, sizeof(payload));


### PR DESCRIPTION
Fixes build when the CONFIG_UPROBES option is absent
Fixes build on various CPU arch.