### PR TITLE
Fix: ACCESS_ONCE was removed in 4.15, use READ_ONCE instead

### DIFF
--- a/probes/lttng-uprobes.c
+++ b/probes/lttng-uprobes.c
@@ -52,11 +52,11 @@ int lttng_uprobes_handler_pre(struct uprobe_consumer *uc, struct pt_regs *regs)
 		unsigned long ip;
 	} payload;
 
-	if (unlikely(!ACCESS_ONCE(chan->session->active)))
+	if (unlikely(!READ_ONCE(chan->session->active)))
 		return 0;
-	if (unlikely(!ACCESS_ONCE(chan->enabled)))
+	if (unlikely(!READ_ONCE(chan->enabled)))
 		return 0;
-	if (unlikely(!ACCESS_ONCE(event->enabled)))
+	if (unlikely(!READ_ONCE(event->enabled)))
 		return 0;
 
 	lib_ring_buffer_ctx_init(&ctx, chan->chan, &lttng_probe_ctx,


### PR DESCRIPTION
Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>