### PR TITLE
statedump: Add thread to interrupt

### DIFF
--- a/instrumentation/events/lttng-module/lttng-statedump.h
+++ b/instrumentation/events/lttng-module/lttng-statedump.h
@@ -136,6 +136,7 @@ LTTNG_TRACEPOINT_EVENT(lttng_statedump_interrupt,
 		ctf_integer(unsigned int, irq, irq)
 		ctf_string(name, chip_name)
 		ctf_string(action, action->name ? : "")
+		ctf_integer(pid_t, thread, action->thread != NULL ? action->thread->pid : 0)
 	)
 )
 


### PR DESCRIPTION
Threaded IRQs have a 'thread' parameter to the action, defining which
process to wakeup when the IRQ happens.

Having this information will allow to know which process are IRQ
handling processes and the analyses can track what happens in those
processes to the IRQ that caused them to wake up.

Signed-off-by: Geneviève Bastien <gbastien+lttng@versatic.net>