### PR TITLE
Fix: implicit declarations caused by buffer size checks.

### DIFF
--- a/wrapper/mm.h
+++ b/wrapper/mm.h
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: (GPL-2.0 or LGPL-2.1)
+ *
+ * wrapper/mm.h
+ *
+ * Copyright (C) 2018 Francis Deslauriers <francis.deslauriers@efficios.com>
+ */
+
+#ifndef _LTTNG_WRAPPER_MM_H
+#define _LTTNG_WRAPPER_MM_H
+
+#include <linux/mm.h>
+#include <linux/oom.h>
+
+#include <lttng-kernel-version.h>
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0) \
+		|| LTTNG_UBUNTU_KERNEL_RANGE(4,4,25,44, 4,5,0,0))
+
+/*
+ * Returns true if the current estimation of the number of page available is
+ * larger than the number of pages passed as parameter.
+ */
+static inline
+bool wrapper_check_enough_free_pages(unsigned long num_pages)
+{
+	return num_pages < si_mem_available();
+}
+
+#else
+
+static inline
+bool wrapper_check_enough_free_pages(unsigned long num_pages)
+{
+	/*
+	 * The si_mem_available function is not available on this kernel. Since
+	 * we can't reliably know if there is enough memory available, so we
+	 * return true.
+	 */
+	return true;
+}
+#endif
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,8,0))
+static inline
+void wrapper_set_current_oom_origin(void)
+{
+	return set_current_oom_origin();
+}
+
+static inline
+void wrapper_clear_current_oom_origin(void)
+{
+	return clear_current_oom_origin();
+}
+
+#else /* #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,8,0)) */
+
+static inline
+void wrapper_set_current_oom_origin(void)
+{
+	return;
+}
+
+static inline
+void wrapper_clear_current_oom_origin()
+{
+	return;
+}
+#endif /* #else #if (LINUX_VERSION_CODE >= KERNEL_VERSION(3,8,0)) */
+#endif /* _LTTNG_WRAPPER_MM_H */


### PR DESCRIPTION
Issue
=====
Three kernel functions used in the following commit are unavailable on
some supported kernels:

	commit 1f0ab1e
	Prevent allocation of buffers if exceeding available memory

* si_mem_available() was added in kernel 4.6 with commit d02bd27.
* {set, clear}_current_oom_origin() were added in kernel 3.8 with commit:
  e1e12d2f

Solution
========
Add wrappers around these functions such that older kernels will build
with these functions defined as NOP or trivial return value.

wrapper_check_enough_free_pages() uses the si_mem_available() kernel
function to compute if the number pages requested passed as parameter is
smaller than the number of pages available on the machine. If the
si_mem_available() kernel function is unavailable, we always return
true.

wrapper_set_current_oom_origin() function wraps the
set_current_oom_origin() kernel function when it is available.
If set_current_oom_origin() is unavailable the wrapper is empty.

wrapper_clear_current_oom_origin() function wraps the
clear_current_oom_origin() kernel function when it is available.
If clear_current_oom_origin() is unavailable the wrapper is empty.

Drawbacks
=========
None.

Signed-off-by: Francis Deslauriers <francis.deslauriers@efficios.com>