### PR TITLE
Kconfig: fix dependency issue when building in-tree without CONFIG_FTRACE

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2,7 +2,7 @@
 
 config LTTNG
 	tristate "LTTng support"
-	select TRACEPOINTS
+	select TRACING
 	help
 	  LTTng is an open source tracing framework for Linux.
 


### PR DESCRIPTION
When building in-tree, one could disable CONFIG_FTRACE from kernel config which will leave CONFIG_TRACEPOINTS selected by LTTNG modules, but generate a lot of linker errors like below because it leaves out other stuff:

```
trace.c:(.text+0xd86b): undefined reference to `trace_event_buffer_reserve'                                                                                                                                        
ld: trace.c:(.text+0xd8de): undefined reference to `trace_event_buffer_commit'                                                                                                                                     
ld: trace.c:(.text+0xd926): undefined reference to `event_triggers_call'                                                                                                                                           
ld: trace.c:(.text+0xd942): undefined reference to `trace_event_ignore_this_pid'                                                                                                                                   
ld: net/mac80211/trace.o: in function `trace_event_raw_event_drv_tdls_cancel_channel_switch':                                                                                                                      
```

Steps I used to reproduce:
* Get a clone of an upstream stable kernel (I've used linux-5.8.y branch) and use scripts/built-in.sh on it
* Configure a standard x86-64 build, enable built-in LTTNG but disable CONFIG_FTRACE from *Kernel Hacking-->Tracers* using menuconfig
* Build will fail at linking stage