### PR TITLE
fix: fix: tracepoint: Optimize using static_call() (v5.10) for stable…

### DIFF
--- a/lttng-statedump-impl.c
+++ b/lttng-statedump-impl.c
@@ -116,6 +116,24 @@ LTTNG_DEFINE_TRACE(lttng_statedump_process_mnt_ns,
 	TP_ARGS(session, p, mnt_ns));
 #endif
 
+LTTNG_DEFINE_TRACE(lttng_statedump_process_net_ns,
+	TP_PROTO(struct lttng_session *session,
+		struct task_struct *p,
+		struct net *net_ns),
+	TP_ARGS(session, p, net_ns));
+
+LTTNG_DEFINE_TRACE(lttng_statedump_process_user_ns,
+	TP_PROTO(struct lttng_session *session,
+		struct task_struct *p,
+		struct user_namespace *user_ns),
+	TP_ARGS(session, p, user_ns));
+
+LTTNG_DEFINE_TRACE(lttng_statedump_process_uts_ns,
+	TP_PROTO(struct lttng_session *session,
+		struct task_struct *p,
+		struct uts_namespace *uts_ns),
+	TP_ARGS(session, p, uts_ns));
+
 LTTNG_DEFINE_TRACE(lttng_statedump_network_interface,
 	TP_PROTO(struct lttng_session *session,
 		struct net_device *dev, struct in_ifaddr *ifa),


### PR DESCRIPTION
…-2.12

bb346792c2cb ("fix: tracepoint: Optimize using static_call() (v5.10)")
misses three definitions and causes the following build failures.

ERROR: "__tracepoint_lttng_statedump_process_net_ns" [lttng-statedump.ko] undefined!
ERROR: "__tracepoint_lttng_statedump_process_user_ns" [lttng-statedump.ko] undefined!
ERROR: "__tracepoint_lttng_statedump_process_uts_ns" [lttng-statedump.ko] undefined!

Fixes: #1290

Signed-off-by: He Zhe <zhe.he@windriver.com>