### PR TITLE
fix: random: remove unused tracepoints (v5.10, v5.15)

### DIFF
--- a/src/probes/Kbuild
+++ b/src/probes/Kbuild
@@ -204,7 +204,10 @@ endif
 
 # Introduced in v3.6, remove in v5.18
 obj-$(CONFIG_LTTNG) +=  $(shell \
-    if [ \( ! \( $(VERSION) -ge 6 -o \( $(VERSION) -eq 5 -a $(PATCHLEVEL) -ge 18 \) \) \) \
+    if [ \( ! \( $(VERSION) -ge 6 \
+      -o \( $(VERSION) -eq 5 -a $(PATCHLEVEL) -ge 18 \) \
+      -o \( $(VERSION) -eq 5 -a $(PATCHLEVEL) -eq 15 -a $(SUBLEVEL) -ge 44 \) \
+      -o \( $(VERSION) -eq 5 -a $(PATCHLEVEL) -eq 10 -a $(SUBLEVEL) -ge 119\) \) \) \
       -a \
       $(VERSION) -ge 4 \
       -o \( $(VERSION) -eq 3 -a $(PATCHLEVEL) -ge 6 \) \


### PR DESCRIPTION
The following kernel commit has been back ported to v5.10.119 and v5.15.44.

commit 14c174633f349cb41ea90c2c0aaddac157012f74
Author: Jason A. Donenfeld <Jason@zx2c4.com>
Date:   Thu Feb 10 16:40:44 2022 +0100

  random: remove unused tracepoints

  These explicit tracepoints aren't really used and show sign of aging.
  It's work to keep these up to date, and before I attempted to keep them
  up to date, they weren't up to date, which indicates that they're not
  really used. These days there are better ways of introspecting anyway.

Signed-off-by: He Zhe <zhe.he@windriver.com>