### PR TITLE
fix: Import VFS namespace for android common kernel

### DIFF
--- a/src/wrapper/kallsyms.c
+++ b/src/wrapper/kallsyms.c
@@ -113,3 +113,7 @@ unsigned long wrapper_kallsyms_lookup_name(const char *name)
 EXPORT_SYMBOL_GPL(wrapper_kallsyms_lookup_name);
 
 #endif
+
+#ifdef CONFIG_ANDROID
+MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
+#endif


### PR DESCRIPTION
Android GKI kernel add limitation on fs interface usage. 
Need to import VFS namespace explicitly to make it workable for lttng-modules.