### PR TITLE
fix: pass read length instead of requested length in kvm_mmio tp handling

### DIFF
--- a/include/instrumentation/events/kvm.h
+++ b/include/instrumentation/events/kvm.h
@@ -105,7 +105,8 @@ LTTNG_TRACEPOINT_EVENT(kvm_mmio,
 		ctf_integer(u32, type, type)
 		ctf_integer(u32, len, len)
 		ctf_integer(u64, gpa, gpa)
-		ctf_sequence_hex(unsigned char, val, val, u32, len)
+		ctf_sequence_hex(unsigned char, val, val, u32,
+			type == KVM_TRACE_MMIO_READ_UNSATISFIED ? 0 : len)
 	)
 )
 


### PR DESCRIPTION
In case of unsatisfied MMIO read, nothing is read and value is null. And value length should also be zero. But during kvm_mmio tracepoint processing for unsatisfied read, length of requested read is being passed instead of length of actual read resulting in dereference of null pointer.